### PR TITLE
Rotate marker icon on motion initialization

### DIFF
--- a/src/leaflet.motion.js
+++ b/src/leaflet.motion.js
@@ -77,6 +77,13 @@ L.Motion.Animate = {
 			this.__marker.addTo(map);
 		}
 
+		if(this.__marker._icon && this.__marker._icon.children.length){
+			var baseRotationAngle = marker._icon.children[0].getAttribute("motion-base");
+			if(baseRotationAngle){
+				this.__marker._icon.children[0].style.transform = "rotate(" + baseRotationAngle + "deg)";
+			}	
+		}
+		
 		if (this.motionOptions.auto) {
 			this.motionStart();
 		}

--- a/src/leaflet.motion.js
+++ b/src/leaflet.motion.js
@@ -78,12 +78,12 @@ L.Motion.Animate = {
 		}
 
 		if(this.__marker._icon && this.__marker._icon.children.length){
-			var baseRotationAngle = marker._icon.children[0].getAttribute("motion-base");
+			var baseRotationAngle = this.__marker._icon.children[0].getAttribute("motion-base");
 			if(baseRotationAngle){
 				this.__marker._icon.children[0].style.transform = "rotate(" + baseRotationAngle + "deg)";
 			}	
 		}
-		
+
 		if (this.motionOptions.auto) {
 			this.motionStart();
 		}


### PR DESCRIPTION
If motionStart is postponed, marker should be rotated by "motion-base" degs on initialization (IMHO)